### PR TITLE
corrected json blob mime type

### DIFF
--- a/src/store/assets.ts
+++ b/src/store/assets.ts
@@ -71,7 +71,7 @@ export const useAssets = defineStore({
       const date = new Date();
       anchor.download = `Starforged-assets-${date.getTime() / 1000}.json`;
       anchor.href = window.URL.createObjectURL(blob);
-      anchor.dataset.downloadurl = ['text/json', anchor.download, anchor.href].join(':');
+      anchor.dataset.downloadurl = ['application/json', anchor.download, anchor.href].join(':');
 
       anchor.dispatchEvent(event);
     },

--- a/src/store/campaign.ts
+++ b/src/store/campaign.ts
@@ -215,7 +215,7 @@ export const useCampaign = defineStore({
       const date = new Date();
       anchor.download = `Starforged-campaign-${date.getTime() / 1000}.json`;
       anchor.href = window.URL.createObjectURL(blob);
-      anchor.dataset.downloadurl = ['text/json', anchor.download, anchor.href].join(':');
+      anchor.dataset.downloadurl = ['application/json', anchor.download, anchor.href].join(':');
 
       anchor.dispatchEvent(event);
     },


### PR DESCRIPTION
the blob had a MIME type of `text/plain`, which was causing iOS to "helpfully" append the `.txt` extension to the JSON data. since IOS doesn't allow users to change file extensions, this was making it impossible to load it without getting a desktop involved.

i've changed the blob type to the technically-more-correct `application/json`. now the file saves with the correct extension on iOS, and the campaign data can be loaded from it.