### PR TITLE
Oracle ID fixes for sector names, derelicts; bump dataforged to 1.4.1

### DIFF
--- a/src/components/Oracles/ODerelict.vue
+++ b/src/components/Oracles/ODerelict.vue
@@ -56,7 +56,9 @@ export default defineComponent({
         data.value.location = oracle.roll('Starforged/Oracles/Derelicts/Location') as ESLocation;
       },
       Type: () => {
-        data.value.type = oracle.roll(`Starforged/Oracles/Derelicts/Type/${data.value.location}`) as EDerelictType;
+        data.value.type = oracle.roll(
+          `Starforged/Oracles/Derelicts/Type/${data.value.location.replace(' ', '_')}`
+        ) as EDerelictType;
       },
       Name: () => {
         data.value.name =

--- a/src/lib/sector.ts
+++ b/src/lib/sector.ts
@@ -176,8 +176,8 @@ export const CellLabel = (c: ISectorCell, id: string) => {
 
 export const NewSector = (): ISector => {
   return {
-    name: `${oracle.roll('Starforged/Oracles/Sector_Name/Prefix')} ${oracle.roll(
-      'Starforged/Oracles/Sector_Name/Suffix'
+    name: `${oracle.roll('Starforged/Oracles/Space/Sector_Name/Prefix')} ${oracle.roll(
+      'Starforged/Oracles/Space/Sector_Name/Suffix'
     )}`,
     region: ERegion.Terminus,
     control: '',
@@ -188,7 +188,7 @@ export const NewSector = (): ISector => {
 export const NewStar = (): IStar => {
   return {
     name: oracle.star(),
-    description: oracle.roll('Starforged/Oracles/Stellar_Object'),
+    description: oracle.roll('Starforged/Oracles/Space/Stellar_Object'),
   };
 };
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3620,9 +3620,9 @@ csstype@^2.6.8:
   integrity sha512-/WwNkdXfckNgw6S5R125rrW8ez139lBHWouiBvX8dfMFtcn6V81REDqnH7+CRpRipfYlyU1CmOnOxrmGcFOjeA==
 
 dataforged@^1.2.2:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/dataforged/-/dataforged-1.2.3.tgz#b428932e67254eb8e6e70197b11606b5d6b170f9"
-  integrity sha512-Mq0io9PJ4rN0ofOcX5W1apxgHgqE3Ibpd0OR9uDkZaZ9riP14VvLO4qRq6kc3z4vbylH9MihG23mpmY1qBdPSA==
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/dataforged/-/dataforged-1.4.1.tgz#a273d0dd631b5daab3b7db31ce07d5b36a28a6c6"
+  integrity sha512-ikE0jnFpIh8SC+UTxcSebBaDlPSvgIKAZ3TOwcJTViXBP1wc84W3e4tqtp3rdrCPjjje71rfNVmsMFWMVlo7Eg==
 
 debug@2.6.9, debug@^2.2.0, debug@^2.6.8, debug@^2.6.9:
   version "2.6.9"


### PR DESCRIPTION
the dataforged bump was mostly to take advantage of the `RollableOraclesSF` that i just added for typechecking oracle IDs in function arguments. then i realized that refactoring the lookup/roll functions would require a parallel enum for setting truths. i can take a look at doing that, but for the time being it's probably a good idea to get this fix out there.

i've left the dependency bump intact intact because it'll probably need to be done at some point anyways. truths, oracles, and moves all seem to be normal, but i'm submitting this for review just to be sure i didn't break something and miss it.