### PR TITLE
replace scrolltotop with expandable fab for navigation

### DIFF
--- a/src/layouts/MainLayout.vue
+++ b/src/layouts/MainLayout.vue
@@ -3,12 +3,8 @@
     <q-header elevated class="bg-secondary text-white" height-hint="98">
       <q-toolbar :class="{ crt: crt }">
         <q-btn dense flat icon="menu" @click="toggleLeftDrawer" />
-        <!--q-avatar rounded>
-          <img src="~/../../public/logo.png" />
-        </q-avatar-->
 
         <q-toolbar-title class="sf-header text-h6">
-          <!--q-input input-class="sf-header text-h5" v-model="campaign.data.name" borderless /-->
           IRON JOURNAL <span class="title-pipe">|</span> STARFORGED
         </q-toolbar-title>
 
@@ -166,7 +162,7 @@
     >
       <!-- right drawer content -->
       <div class="row">
-        <q-expansion-item class="col-12">
+        <q-expansion-item class="col-12" id="oracles">
           <template v-slot:header>
             <div class="text-h4 sf-header col-grow">ORACLES</div>
           </template>
@@ -175,7 +171,7 @@
       </div>
 
       <div class="row">
-        <q-expansion-item class="col-12">
+        <q-expansion-item class="col-12" id="moves">
           <template v-slot:header>
             <div class="text-h4 sf-header col-grow">MOVES</div>
           </template>
@@ -183,16 +179,20 @@
         </q-expansion-item>
       </div>
 
+      <div id="journal" />
       <journal />
 
-      <q-btn
-        class="journal-to-top"
-        fab
-        color="primary"
-        @click="scrollTo('rightDrawer')"
-        icon="mdi-arrow-up"
-        size="sm"
-      />
+      <q-fab color="primary" icon="keyboard_arrow_left" direction="left" class="journal-to-top">
+        <q-fab-action color="primary" @click="scrollTo('oracles')" icon="mdi-dice-multiple">
+          <q-tooltip>Scroll to Oracles</q-tooltip>
+        </q-fab-action>
+        <q-fab-action color="primary" @click="scrollTo('moves')" icon="mdi-file-document-multiple">
+          <q-tooltip>Scroll to Moves</q-tooltip>
+        </q-fab-action>
+        <q-fab-action color="primary" @click="scrollTo('journal')" icon="mdi-notebook">
+          <q-tooltip>Scroll to Journal</q-tooltip>
+        </q-fab-action>
+      </q-fab>
     </q-drawer>
 
     <q-page-container>


### PR DESCRIPTION
First pass on improving right drawer navigation by using an expandable set of buttons to allow immediate scrolling to each of the 3 major sections