### PR TITLE
Custom Oracle UX Improvements

### DIFF
--- a/src/components/Oracles/OCustom.vue
+++ b/src/components/Oracles/OCustom.vue
@@ -5,7 +5,7 @@
       <q-btn class="col-shrink" icon="add_circle" flat dense @click="$emit('new')" />
     </div>
     <o-input
-      v-for="(o, i) of oracles.data"
+      v-for="(o, i) of sortedOracleData"
       :key="i"
       :label="o.Name"
       v-model="results[i]"
@@ -18,7 +18,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, Ref, ref } from 'vue';
+import { defineComponent, Ref, ref, computed } from 'vue';
 
 import { useOracles } from 'src/store/oracles';
 
@@ -35,9 +35,12 @@ export default defineComponent({
     const results: Ref<string[]> = ref(new Array(oracles.data.length).fill('') as string[]);
     const roll = (id: string, index: number) => (results.value[index] = rollCustom(id));
     const clear = () => results.value.forEach((r, i) => (results.value[i] = ''));
+    const sortedOracleData = computed(() => {
+      return [...oracles.data].sort((a, b) => a.Name.localeCompare(b.Name));
+    });
 
     return {
-      oracles,
+      sortedOracleData,
       results,
       roll,
       clear,

--- a/src/components/Oracles/OEditor.vue
+++ b/src/components/Oracles/OEditor.vue
@@ -17,11 +17,7 @@
     </q-card-section>
 
     <q-card-section>
-      <div class="row justify-between items-center q-ml-sm">
-        <div class="col-grow text-bold">Add Row</div>
-        <q-btn class="col-shrink" icon="add_circle" flat dense @click="addRow" />
-      </div>
-      <div class="row q-ml-sm items-center" v-for="(row, index) of data.Table" :key="index">
+      <div class="row q-ml-sm items-center q-mb-sm" v-for="(row, index) of data.Table" :key="index">
         <q-input class="col-2" type="number" v-model.number="data.Table![index].Floor" label="Floor" dense />
         <q-input class="col-2" type="number" v-model.number="data.Table![index].Ceiling" label="Ceiling" dense />
         <q-input class="col" v-model="data.Table![index].Result" label="Result Text" dense />
@@ -32,10 +28,13 @@
           <q-tooltip>Remove row</q-tooltip>
         </q-btn>
       </div>
+      <div class="row justify-between items-center q-ml-sm">
+        <div class="col-grow text-bold">Add Row</div>
+        <q-btn class="col-shrink" icon="add_circle" flat dense @click="addRow" />
+      </div>
     </q-card-section>
     <q-card-actions class="justify-between row">
       <div class="col-shrink">
-        <q-btn label="Delete" flat class="self-start" color="warning" @click="del" />
         <q-btn label="Delete" flat class="self-start" color="warning" @click="del" v-if="isExistingOracle" />
       </div>
       <div class="col-shrink">

--- a/src/components/Oracles/OEditor.vue
+++ b/src/components/Oracles/OEditor.vue
@@ -36,6 +36,7 @@
     <q-card-actions class="justify-between row">
       <div class="col-shrink">
         <q-btn label="Delete" flat class="self-start" color="warning" @click="del" />
+        <q-btn label="Delete" flat class="self-start" color="warning" @click="del" v-if="isExistingOracle" />
       </div>
       <div class="col-shrink">
         <q-btn
@@ -162,6 +163,10 @@ export default defineComponent({
           emit('close');
         });
 
+    const isExistingOracle = computed((): boolean => {
+      return oracles.data.findIndex((oracle) => oracle.$id == data.value.$id) != -1;
+    });
+
     return {
       data,
       diceNum,
@@ -171,6 +176,7 @@ export default defineComponent({
       save,
       del,
       badRows,
+      isExistingOracle,
     };
   },
 });


### PR DESCRIPTION
Some minor changes to that came up in the Discord:

- Custom Oracles are sorted alphabetically
- The Add Row button is now positioned below the rows, so there's no need to always scroll up when adding many rows.
- When first creating a custom oracle, the Delete button is hidden, since the oracle is not yet saved and the Close button does the same thing in that case.